### PR TITLE
Inferring and setting the locale for each request.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,17 +5,22 @@ class ApplicationController < ActionController::Base
   # preventing modals from loading entire pages
   layout proc { |controller| controller.request.xhr? ? false : 'application' }
 
+  protected
+
   def set_locale
-    logger.debug "set_locale is passed options: #{params[:locale]}\n"
-    # if params[:locale] is nil then I18n.default_locale will be used
-    if user_signed_in?
-      I18n.locale = current_user.locale || "en"
+    I18n.locale = infer_locale
+  end
+
+  def infer_locale
+    if params[:locale].present?
+      params[:locale]
+    elsif user_signed_in?
+      current_user.locale
     else
-      I18n.locale = "en"
+      I18n.default_locale
     end
   end
 
-  protected
   def after_sign_in_path_for(user)
     logger.debug "called from after_sign_in_path"
     unless self.controller_name == "invitations"

--- a/spec/controllers/corkboard_controller_spec.rb
+++ b/spec/controllers/corkboard_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+describe CorkboardController do
+
+  context 'locale inference' do
+    let(:user) { Factory.create(:user) }
+    before(:each) do
+      sign_in user
+    end
+
+    it 'should be set with a user preference' do
+      user.update_attribute(:locale,'de')
+      get :index
+      I18n.locale.should == :de
+    end
+
+    it 'should be overridable via params[:locale]' do
+      get :index, :locale => 'fr'
+      I18n.locale.should == :fr
+    end
+
+    it 'should default to english' do
+      get :index
+      I18n.locale.should == :en
+    end
+
+  end
+end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+describe HomeController do
+  context 'locale inference' do
+    it 'should default to english' do
+      get :index
+      I18n.locale.should == :en
+    end
+
+    it 'should be overridable via params[:locale]' do
+      get :index, :locale => 'fr'
+      I18n.locale.should == :fr
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,5 +4,6 @@ Factory.define :user do |u|
   u.name 'Test User'
   u.email 'user@test.com'
   u.password 'please'
+  u.invitation_token 'faketoken'
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ RSpec.configure do |config|
   # config.use_transactional_fixtures = true
 
   # Other things
+  config.include Devise::TestHelpers, :type => :controller
 
   # Clean up the database
   require 'database_cleaner'


### PR DESCRIPTION
Using this order of precedence:
1. params[:locale]
2. current_user.locale
3. I18n.default_locale

Also moving `set_locale` & `infer_locale` to the `protected` scope
